### PR TITLE
updated exercise 2, inner join, to just have 3 columns that match the…

### DIFF
--- a/final.ipynb
+++ b/final.ipynb
@@ -20,7 +20,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 72,
+      "execution_count": 2,
       "metadata": {
         "id": "DBhZwsv4nB1d"
       },
@@ -171,7 +171,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 73,
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -263,7 +263,7 @@
               "4           5      David  Robinson        10th  student5@school.com"
             ]
           },
-          "execution_count": 73,
+          "execution_count": 3,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -280,7 +280,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 74,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -317,7 +317,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 75,
+      "execution_count": 5,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -472,7 +472,7 @@
               "11          30   Isabella   Anderson        12th  student30@school.com"
             ]
           },
-          "execution_count": 75,
+          "execution_count": 5,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -489,7 +489,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 76,
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -526,7 +526,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 77,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -618,7 +618,7 @@
               "4           6      Sarah    Garcia        10th   student6@school.com"
             ]
           },
-          "execution_count": 77,
+          "execution_count": 7,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -635,7 +635,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 78,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -673,7 +673,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 79,
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -765,7 +765,7 @@
               "4          11       Alex      Jones        12th  student11@school.com"
             ]
           },
-          "execution_count": 79,
+          "execution_count": 9,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -783,7 +783,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 80,
+      "execution_count": 10,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -872,7 +872,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 81,
+      "execution_count": 11,
       "metadata": {
         "id": "O0fDhR0J2DFq"
       },
@@ -1016,7 +1016,7 @@
               "[300 rows x 5 columns]"
             ]
           },
-          "execution_count": 81,
+          "execution_count": 11,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -1035,7 +1035,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 82,
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1078,7 +1078,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 83,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1203,7 +1203,7 @@
               "[300 rows x 3 columns]"
             ]
           },
-          "execution_count": 83,
+          "execution_count": 13,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -1222,7 +1222,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 84,
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1287,26 +1287,66 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 85,
+      "execution_count": 15,
       "metadata": {
         "id": "CSY0UdZThguJ"
       },
       "outputs": [
         {
-          "ename": "OperationalError",
-          "evalue": "near \"YOUR\": syntax error",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[1;31mOperationalError\u001b[0m                          Traceback (most recent call last)",
-            "Cell \u001b[1;32mIn[85], line 5\u001b[0m\n\u001b[0;32m      1\u001b[0m insert_query \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;124mYOUR QUERY HERE\u001b[39m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[1;32m----> 5\u001b[0m \u001b[43mconn\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43minsert_query\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      6\u001b[0m conn\u001b[38;5;241m.\u001b[39mcommit()\n\u001b[0;32m      8\u001b[0m student_31 \u001b[38;5;241m=\u001b[39m sql(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSELECT * FROM students WHERE student_id = 31\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-            "\u001b[1;31mOperationalError\u001b[0m: near \"YOUR\": syntax error"
-          ]
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>31</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Doe</td>\n",
+              "      <td>12</td>\n",
+              "      <td>student31@school.com</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   student_id first_name last_name grade_level                 email\n",
+              "0          31       John       Doe          12  student31@school.com"
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {},
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "insert_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "INSERT INTO students\n",
+        "VALUES (31, 'John', 'Doe', '12', 'student31@school.com')\n",
         "\"\"\"\n",
         "\n",
         "conn.execute(insert_query)\n",
@@ -1318,11 +1358,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 16,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "INSERT query was not successful\n"
+          ]
+        }
+      ],
       "source": [
-        "test_instance.insert_test(insert_query)"
+        "test_instance.insert_test(insert_query)  #unsure why this says unsuccessful, as it appears to match the requirements of the insert test function"
       ]
     },
     {
@@ -1353,7 +1401,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1362,10 +1410,55 @@
         "id": "fYMz66Uajiux",
         "outputId": "3c50656e-812a-4dc7-f1b6-532f26cfde94"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "Empty DataFrame\n",
+              "Columns: [student_id, first_name, last_name, grade_level, email]\n",
+              "Index: []"
+            ]
+          },
+          "execution_count": 17,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "delete_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "DELETE FROM students\n",
+        "WHERE student_id = 31;\n",
         "\"\"\"\n",
         "\n",
         "conn.execute(delete_query)\n",
@@ -1377,16 +1470,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "DELETE query was successful\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.delete_test(delete_query)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 19,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1395,12 +1496,24 @@
         "id": "LOYUTPcMjeKT",
         "outputId": "3e26c8b8-9654-4211-89ec-48105b05c2e1"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "\"\\n  INSERT INTO students\\n  VALUES (31, 'John', 'Doe', '12', 'student31@school.com')\\n  \""
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "def insert_query():\n",
         "  insert_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
-        "\"\"\"\n",
+        "  INSERT INTO students\n",
+        "  VALUES (31, 'John', 'Doe', '12', 'student31@school.com')\n",
+        "  \"\"\"\n",
         "\n",
         "  conn.execute(insert_query)\n",
         "  conn.commit()\n",
@@ -1446,7 +1559,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 20,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1455,10 +1568,63 @@
         "id": "DrtH2lI3jOMw",
         "outputId": "f74470d5-2340-4955-df36-d217d2ab6ace"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>31</td>\n",
+              "      <td>Jane</td>\n",
+              "      <td>Doe</td>\n",
+              "      <td>12</td>\n",
+              "      <td>student31@school.com</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   student_id first_name last_name grade_level                 email\n",
+              "0          31       Jane       Doe          12  student31@school.com"
+            ]
+          },
+          "execution_count": 20,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "update_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "UPDATE students\n",
+        "SET first_name = 'Jane'\n",
+        "WHERE student_id = 31;\n",
         "\"\"\"\n",
         "\n",
         "conn.execute(update_query)\n",
@@ -1470,25 +1636,41 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 21,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "UPDATE query was not successful\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.update_query_test(update_query)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 22,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Student 31 has been removed\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.delete_query()"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 23,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1497,7 +1679,27 @@
         "id": "JAb4Hk7NkceJ",
         "outputId": "f067eec3-125b-45ed-a899-c5ee353e221a"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "DatabaseError",
+          "evalue": "Execution failed on sql '\nYOUR QUERY HERE\n': near \"YOUR\": syntax error",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[1;31mOperationalError\u001b[0m                          Traceback (most recent call last)",
+            "File \u001b[1;32mc:\\Users\\turrr\\Documents\\data-path-projects\\sql_final\\SQL_Test\\env\\Lib\\site-packages\\pandas\\io\\sql.py:2674\u001b[0m, in \u001b[0;36mSQLiteDatabase.execute\u001b[1;34m(self, sql, params)\u001b[0m\n\u001b[0;32m   2673\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m-> 2674\u001b[0m     \u001b[43mcur\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   2675\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m cur\n",
+            "\u001b[1;31mOperationalError\u001b[0m: near \"YOUR\": syntax error",
+            "\nThe above exception was the direct cause of the following exception:\n",
+            "\u001b[1;31mDatabaseError\u001b[0m                             Traceback (most recent call last)",
+            "Cell \u001b[1;32mIn[23], line 5\u001b[0m\n\u001b[0;32m      1\u001b[0m query \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;124mYOUR QUERY HERE\u001b[39m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[1;32m----> 5\u001b[0m \u001b[43msql\u001b[49m\u001b[43m(\u001b[49m\u001b[43mquery\u001b[49m\u001b[43m)\u001b[49m\n",
+            "File \u001b[1;32mc:\\Users\\turrr\\Documents\\data-path-projects\\sql_final\\SQL_Test\\db_builder.py:88\u001b[0m, in \u001b[0;36mSchoolDataGenerator.sql\u001b[1;34m(self, query)\u001b[0m\n\u001b[0;32m     87\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msql\u001b[39m(\u001b[38;5;28mself\u001b[39m, query):\n\u001b[1;32m---> 88\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_sql_query\u001b[49m\u001b[43m(\u001b[49m\u001b[43mquery\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconn\u001b[49m\u001b[43m)\u001b[49m\n",
+            "File \u001b[1;32mc:\\Users\\turrr\\Documents\\data-path-projects\\sql_final\\SQL_Test\\env\\Lib\\site-packages\\pandas\\io\\sql.py:526\u001b[0m, in \u001b[0;36mread_sql_query\u001b[1;34m(sql, con, index_col, coerce_float, params, parse_dates, chunksize, dtype, dtype_backend)\u001b[0m\n\u001b[0;32m    523\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m dtype_backend \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m lib\u001b[38;5;241m.\u001b[39mno_default\n\u001b[0;32m    525\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m pandasSQL_builder(con) \u001b[38;5;28;01mas\u001b[39;00m pandas_sql:\n\u001b[1;32m--> 526\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mpandas_sql\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_query\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m    527\u001b[0m \u001b[43m        \u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    528\u001b[0m \u001b[43m        \u001b[49m\u001b[43mindex_col\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mindex_col\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    529\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparams\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparams\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    530\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcoerce_float\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcoerce_float\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    531\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparse_dates\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparse_dates\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    532\u001b[0m \u001b[43m        \u001b[49m\u001b[43mchunksize\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mchunksize\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    533\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdtype\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    534\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdtype_backend\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdtype_backend\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    535\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+            "File \u001b[1;32mc:\\Users\\turrr\\Documents\\data-path-projects\\sql_final\\SQL_Test\\env\\Lib\\site-packages\\pandas\\io\\sql.py:2738\u001b[0m, in \u001b[0;36mSQLiteDatabase.read_query\u001b[1;34m(self, sql, index_col, coerce_float, parse_dates, params, chunksize, dtype, dtype_backend)\u001b[0m\n\u001b[0;32m   2727\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mread_query\u001b[39m(\n\u001b[0;32m   2728\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[0;32m   2729\u001b[0m     sql,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m   2736\u001b[0m     dtype_backend: DtypeBackend \u001b[38;5;241m|\u001b[39m Literal[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnumpy\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnumpy\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[0;32m   2737\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DataFrame \u001b[38;5;241m|\u001b[39m Iterator[DataFrame]:\n\u001b[1;32m-> 2738\u001b[0m     cursor \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   2739\u001b[0m     columns \u001b[38;5;241m=\u001b[39m [col_desc[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m col_desc \u001b[38;5;129;01min\u001b[39;00m cursor\u001b[38;5;241m.\u001b[39mdescription]\n\u001b[0;32m   2741\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m chunksize \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+            "File \u001b[1;32mc:\\Users\\turrr\\Documents\\data-path-projects\\sql_final\\SQL_Test\\env\\Lib\\site-packages\\pandas\\io\\sql.py:2686\u001b[0m, in \u001b[0;36mSQLiteDatabase.execute\u001b[1;34m(self, sql, params)\u001b[0m\n\u001b[0;32m   2683\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ex \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01minner_exc\u001b[39;00m\n\u001b[0;32m   2685\u001b[0m ex \u001b[38;5;241m=\u001b[39m DatabaseError(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mExecution failed on sql \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00msql\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexc\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m-> 2686\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m ex \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mexc\u001b[39;00m\n",
+            "\u001b[1;31mDatabaseError\u001b[0m: Execution failed on sql '\nYOUR QUERY HERE\n': near \"YOUR\": syntax error"
+          ]
+        }
+      ],
       "source": [
         "query = \"\"\"\n",
         "YOUR QUERY HERE\n",
@@ -1558,10 +1760,104 @@
         "id": "fEJvzqYk3_BE",
         "outputId": "fbad056c-b6a2-496a-b038-fce24e5e9866"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>grade</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   student_id first_name last_name grade_level grade\n",
+              "0           1       Ryan   Sanchez        12th     A\n",
+              "1           1       Ryan   Sanchez        12th     A\n",
+              "2           1       Ryan   Sanchez        12th     A\n",
+              "3           1       Ryan   Sanchez        12th     A\n",
+              "4           1       Ryan   Sanchez        12th     B"
+            ]
+          },
+          "execution_count": 131,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "Logical_operators = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT s.student_id, s.first_name, s.last_name, s.grade_level, g.grade\n",
+        "FROM students s\n",
+        "LEFT JOIN grades g\n",
+        "    ON s.student_id = g.student_id\n",
+        "WHERE (g.grade = 'A' OR g.grade = 'B' OR g.grade IS NULL)\n",
+        "AND s.grade_level = '12th';\n",
+        "\n",
+        "\n",
         "\"\"\"\n",
         "\n",
         "sql(Logical_operators).head()"
@@ -1571,7 +1867,15 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Logical_operators query was successful with correct columns, grade_level, and grade\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.logical_operators_test(Logical_operators)"
       ]
@@ -1607,10 +1911,155 @@
         "id": "GvwdBYS47igS",
         "outputId": "5e581afd-4733-408b-db3f-f253576774c8"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>grade</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "    student_id first_name last_name grade_level grade\n",
+              "0            3       John     Smith        12th     B\n",
+              "1            3       John     Smith        12th     B\n",
+              "2            3       John     Smith        12th     C\n",
+              "3            3       John     Smith        12th     C\n",
+              "4            3       John     Smith        12th     C\n",
+              "5            4        Ava    Harris        12th     A\n",
+              "6            4        Ava    Harris        12th     A\n",
+              "7            4        Ava    Harris        12th     A\n",
+              "8            4        Ava    Harris        12th     A\n",
+              "9            4        Ava    Harris        12th     B\n",
+              "10           4        Ava    Harris        12th     C"
+            ]
+          },
+          "execution_count": 134,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "filter_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT s.student_id, s.first_name, s.last_name, s.grade_level, g.grade\n",
+        "FROM students s\n",
+        "INNER JOIN grades g\n",
+        "    ON s.student_id = g.student_id\n",
+        "WHERE s.student_id BETWEEN 1 AND 8 AND (s.first_name LIKE 'A%' OR s.first_name LIKE 'J%') AND g.grade IN ('A', 'B', 'C');\n",
         "\"\"\"\n",
         "\n",
         "filter_result = sql(filter_query)\n",
@@ -1621,7 +2070,15 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "filter_query was successful with correct columns, student_id, first_name, and grade\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.filter_query_test(filter_query)"
       ]
@@ -1658,10 +2115,72 @@
         "id": "oWZLqnk7bnqa",
         "outputId": "3da6389a-32c8-495a-dc95-c666f5c1370c"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>average_grade</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>10th</td>\n",
+              "      <td>72.660000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>11th</td>\n",
+              "      <td>70.925000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>12th</td>\n",
+              "      <td>69.066667</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  grade_level  average_grade\n",
+              "0        10th      72.660000\n",
+              "1        11th      70.925000\n",
+              "2        12th      69.066667"
+            ]
+          },
+          "execution_count": 151,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "groupby_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "\n",
+        "SELECT s.grade_level, AVG(numeric_score) AS [average_grade]\n",
+        "FROM grades g\n",
+        "INNER JOIN students s\n",
+        "    ON g.student_id = s.student_id\n",
+        "GROUP BY s.grade_level;\n",
         "\"\"\"\n",
         "\n",
         "groupby_result = sql(groupby_query)\n",
@@ -1672,7 +2191,15 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Test passed successfully: Provided query matches the expected results\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.groupby_query_test(groupby_query)"
       ]
@@ -1705,7 +2232,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 34,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1714,10 +2241,79 @@
         "id": "2DQ3Zj3emyDN",
         "outputId": "58fd8a36-c276-431f-c7e3-779fb005db6f"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>average_grade</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>10th</td>\n",
+              "      <td>2.170000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>11th</td>\n",
+              "      <td>2.175000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>12th</td>\n",
+              "      <td>1.916667</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  grade_level  average_grade\n",
+              "0        10th       2.170000\n",
+              "1        11th       2.175000\n",
+              "2        12th       1.916667"
+            ]
+          },
+          "execution_count": 34,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "gpa_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT s.grade_level, AVG(\n",
+        "CASE\n",
+        "    WHEN g.grade = 'A' THEN 4\n",
+        "    WHEN g.grade = 'B' THEN 3\n",
+        "    WHEN g.grade = 'C' THEN 2\n",
+        "    WHEN g.grade = 'D' THEN 1\n",
+        "    ELSE 0\n",
+        "END) AS [average_grade]\n",
+        "FROM grades g\n",
+        "INNER JOIN students s\n",
+        "    ON g.student_id = s.student_id\n",
+        "\n",
+        "GROUP BY s.grade_level;\n",
         "\"\"\"\n",
         "\n",
         "gpa_result = sql(gpa_query)\n",
@@ -1726,7 +2322,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 35,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1734,7 +2330,15 @@
         "id": "jxMD_z3Ckg9u",
         "outputId": "00877c8b-6a86-482b-f065-6845244c143f"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Test passed successfully\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.test_gpa_query(gpa_result)"
       ]
@@ -1756,14 +2360,15 @@
         "- 'A' for scores of 90 and above\n",
         "- 'B' for scores between 80 and 89\n",
         "- 'C' for scores between 70 and 79\n",
-        "- 'F' for scores below 70\n",
+        "- 'D' for scores between 60 and 69\n",
+        "- 'F' for scores below 60\n",
         "\n",
-        "Your query should include the following columns: `first_name`, `last_name`, `grade`, `numeric_score`, and the newly created `grade_category`.\n"
+        "Your query should include the following columns: `first_name`, `last_name`, `grade`, `numeric_score`, and the newly created `grade_check`.\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 42,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1772,10 +2377,332 @@
         "id": "h8kJNkcEWWpE",
         "outputId": "a4a53e6a-3e55-4bae-d9b3-77f1b0d839b0"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade</th>\n",
+              "      <th>numeric_score</th>\n",
+              "      <th>grade_check</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>F</td>\n",
+              "      <td>12</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>90</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>B</td>\n",
+              "      <td>84</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>93</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>96</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>C</td>\n",
+              "      <td>77</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>C</td>\n",
+              "      <td>72</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>C</td>\n",
+              "      <td>75</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>B</td>\n",
+              "      <td>84</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>99</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>B</td>\n",
+              "      <td>88</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>11</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>B</td>\n",
+              "      <td>82</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>D</td>\n",
+              "      <td>66</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>C</td>\n",
+              "      <td>78</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>14</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>B</td>\n",
+              "      <td>85</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>15</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>93</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>16</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>95</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>17</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>D</td>\n",
+              "      <td>64</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>18</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>A</td>\n",
+              "      <td>93</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>19</th>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>F</td>\n",
+              "      <td>56</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>20</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>C</td>\n",
+              "      <td>73</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>21</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>D</td>\n",
+              "      <td>66</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>22</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>D</td>\n",
+              "      <td>62</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>23</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>C</td>\n",
+              "      <td>72</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>24</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>B</td>\n",
+              "      <td>88</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>25</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>F</td>\n",
+              "      <td>16</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>F</td>\n",
+              "      <td>27</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>27</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>F</td>\n",
+              "      <td>25</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>28</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>C</td>\n",
+              "      <td>73</td>\n",
+              "      <td>C</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>29</th>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>B</td>\n",
+              "      <td>88</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   first_name last_name grade  numeric_score grade_check\n",
+              "0        Ryan   Sanchez     F             12           F\n",
+              "1        Ryan   Sanchez     A             90           A\n",
+              "2        Ryan   Sanchez     B             84           B\n",
+              "3        Ryan   Sanchez     A             93           A\n",
+              "4        Ryan   Sanchez     A             96           A\n",
+              "5        Ryan   Sanchez     C             77           C\n",
+              "6        Ryan   Sanchez     C             72           C\n",
+              "7        Ryan   Sanchez     C             75           C\n",
+              "8        Ryan   Sanchez     B             84           B\n",
+              "9        Ryan   Sanchez     A             99           A\n",
+              "10      Emily   Ramirez     B             88           B\n",
+              "11      Emily   Ramirez     B             82           B\n",
+              "12      Emily   Ramirez     D             66           D\n",
+              "13      Emily   Ramirez     C             78           C\n",
+              "14      Emily   Ramirez     B             85           B\n",
+              "15      Emily   Ramirez     A             93           A\n",
+              "16      Emily   Ramirez     A             95           A\n",
+              "17      Emily   Ramirez     D             64           D\n",
+              "18      Emily   Ramirez     A             93           A\n",
+              "19      Emily   Ramirez     F             56           F\n",
+              "20       John     Smith     C             73           C\n",
+              "21       John     Smith     D             66           D\n",
+              "22       John     Smith     D             62           D\n",
+              "23       John     Smith     C             72           C\n",
+              "24       John     Smith     B             88           B\n",
+              "25       John     Smith     F             16           F\n",
+              "26       John     Smith     F             27           F\n",
+              "27       John     Smith     F             25           F\n",
+              "28       John     Smith     C             73           C\n",
+              "29       John     Smith     B             88           B"
+            ]
+          },
+          "execution_count": 42,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "case_expression = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT s.first_name, s.last_name, g.grade, g.numeric_score,\n",
+        "CASE\n",
+        "    WHEN numeric_score >= 90 THEN 'A'\n",
+        "    WHEN numeric_score >=80 THEN 'B'\n",
+        "    WHEN numeric_score >= 70 THEN 'C'\n",
+        "    WHEN numeric_score >= 60 THEN 'D'\n",
+        "    ELSE 'F'\n",
+        "END AS grade_check\n",
+        "FROM grades g\n",
+        "JOIN students s\n",
+        "    ON g.student_id = s.student_id;\n",
         "\"\"\"\n",
         "\n",
         "case_result = sql(case_expression)\n",
@@ -1784,7 +2711,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 43,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1792,7 +2719,15 @@
         "id": "DbNQC4MWBU5F",
         "outputId": "ce063528-7b48-46b7-cc51-5d461aa23663"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "case_expression query was successful with correct columns and grade_check logic\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.case_expression_test(case_expression)"
       ]

--- a/final.ipynb
+++ b/final.ipynb
@@ -20,7 +20,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 72,
       "metadata": {
         "id": "DBhZwsv4nB1d"
       },
@@ -171,7 +171,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 73,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -182,28 +182,97 @@
       },
       "outputs": [
         {
-          "ename": "DatabaseError",
-          "evalue": "Execution failed on sql '\nYOUR QUERY HERE\n': near \"YOUR\": syntax error",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mOperationalError\u001b[0m                          Traceback (most recent call last)",
-            "File \u001b[0;32m~/Desktop/SQL_Test/venv/lib/python3.13/site-packages/pandas/io/sql.py:2674\u001b[0m, in \u001b[0;36mSQLiteDatabase.execute\u001b[0;34m(self, sql, params)\u001b[0m\n\u001b[1;32m   2673\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 2674\u001b[0m     \u001b[43mcur\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2675\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m cur\n",
-            "\u001b[0;31mOperationalError\u001b[0m: near \"YOUR\": syntax error",
-            "\nThe above exception was the direct cause of the following exception:\n",
-            "\u001b[0;31mDatabaseError\u001b[0m                             Traceback (most recent call last)",
-            "Cell \u001b[0;32mIn[2], line 5\u001b[0m\n\u001b[1;32m      1\u001b[0m select_query \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;124mYOUR QUERY HERE\u001b[39m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m----> 5\u001b[0m \u001b[43msql\u001b[49m\u001b[43m(\u001b[49m\u001b[43mselect_query\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mhead()\n",
-            "File \u001b[0;32m~/Desktop/SQL_Test/db_builder.py:88\u001b[0m, in \u001b[0;36mSchoolDataGenerator.sql\u001b[0;34m(self, query)\u001b[0m\n\u001b[1;32m     87\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msql\u001b[39m(\u001b[38;5;28mself\u001b[39m, query):\n\u001b[0;32m---> 88\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_sql_query\u001b[49m\u001b[43m(\u001b[49m\u001b[43mquery\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconn\u001b[49m\u001b[43m)\u001b[49m\n",
-            "File \u001b[0;32m~/Desktop/SQL_Test/venv/lib/python3.13/site-packages/pandas/io/sql.py:526\u001b[0m, in \u001b[0;36mread_sql_query\u001b[0;34m(sql, con, index_col, coerce_float, params, parse_dates, chunksize, dtype, dtype_backend)\u001b[0m\n\u001b[1;32m    523\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m dtype_backend \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m lib\u001b[38;5;241m.\u001b[39mno_default\n\u001b[1;32m    525\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m pandasSQL_builder(con) \u001b[38;5;28;01mas\u001b[39;00m pandas_sql:\n\u001b[0;32m--> 526\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mpandas_sql\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_query\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    527\u001b[0m \u001b[43m        \u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    528\u001b[0m \u001b[43m        \u001b[49m\u001b[43mindex_col\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mindex_col\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    529\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparams\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparams\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    530\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcoerce_float\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcoerce_float\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    531\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparse_dates\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparse_dates\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    532\u001b[0m \u001b[43m        \u001b[49m\u001b[43mchunksize\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mchunksize\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    533\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdtype\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    534\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdtype_backend\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdtype_backend\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    535\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
-            "File \u001b[0;32m~/Desktop/SQL_Test/venv/lib/python3.13/site-packages/pandas/io/sql.py:2738\u001b[0m, in \u001b[0;36mSQLiteDatabase.read_query\u001b[0;34m(self, sql, index_col, coerce_float, parse_dates, params, chunksize, dtype, dtype_backend)\u001b[0m\n\u001b[1;32m   2727\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mread_query\u001b[39m(\n\u001b[1;32m   2728\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m   2729\u001b[0m     sql,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   2736\u001b[0m     dtype_backend: DtypeBackend \u001b[38;5;241m|\u001b[39m Literal[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnumpy\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnumpy\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m   2737\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DataFrame \u001b[38;5;241m|\u001b[39m Iterator[DataFrame]:\n\u001b[0;32m-> 2738\u001b[0m     cursor \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2739\u001b[0m     columns \u001b[38;5;241m=\u001b[39m [col_desc[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m col_desc \u001b[38;5;129;01min\u001b[39;00m cursor\u001b[38;5;241m.\u001b[39mdescription]\n\u001b[1;32m   2741\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m chunksize \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
-            "File \u001b[0;32m~/Desktop/SQL_Test/venv/lib/python3.13/site-packages/pandas/io/sql.py:2686\u001b[0m, in \u001b[0;36mSQLiteDatabase.execute\u001b[0;34m(self, sql, params)\u001b[0m\n\u001b[1;32m   2683\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m ex \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01minner_exc\u001b[39;00m\n\u001b[1;32m   2685\u001b[0m ex \u001b[38;5;241m=\u001b[39m DatabaseError(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mExecution failed on sql \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00msql\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexc\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m-> 2686\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m ex \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mexc\u001b[39;00m\n",
-            "\u001b[0;31mDatabaseError\u001b[0m: Execution failed on sql '\nYOUR QUERY HERE\n': near \"YOUR\": syntax error"
-          ]
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student1@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>2</td>\n",
+              "      <td>Emily</td>\n",
+              "      <td>Ramirez</td>\n",
+              "      <td>10th</td>\n",
+              "      <td>student2@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student3@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student4@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>5</td>\n",
+              "      <td>David</td>\n",
+              "      <td>Robinson</td>\n",
+              "      <td>10th</td>\n",
+              "      <td>student5@school.com</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   student_id first_name last_name grade_level                email\n",
+              "0           1       Ryan   Sanchez        12th  student1@school.com\n",
+              "1           2      Emily   Ramirez        10th  student2@school.com\n",
+              "2           3       John     Smith        12th  student3@school.com\n",
+              "3           4        Ava    Harris        12th  student4@school.com\n",
+              "4           5      David  Robinson        10th  student5@school.com"
+            ]
+          },
+          "execution_count": 73,
+          "metadata": {},
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "select_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT *\n",
+        "FROM students\n",
+        "WHERE student_id > 0;\n",
         "\"\"\"\n",
         "\n",
         "sql(select_query).head()"
@@ -211,7 +280,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 74,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -219,7 +288,15 @@
         "id": "d-5AMpPPS9g3",
         "outputId": "54d271f9-ddce-4eda-dc7e-cea193ba2a79"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Select query was successful with the correct shape and columns\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.select_test(select_query)"
       ]
@@ -240,7 +317,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 75,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -249,10 +326,162 @@
         "id": "iD9XlBm_9cFP",
         "outputId": "1646d354-57f8-4ca6-a47d-00802b0a47c2"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student1@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>3</td>\n",
+              "      <td>John</td>\n",
+              "      <td>Smith</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student3@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student4@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>7</td>\n",
+              "      <td>Brandon</td>\n",
+              "      <td>Thompson</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student7@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>9</td>\n",
+              "      <td>Zach</td>\n",
+              "      <td>Hernandez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student9@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>10</td>\n",
+              "      <td>Emma</td>\n",
+              "      <td>Rodriguez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student10@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>11</td>\n",
+              "      <td>Alex</td>\n",
+              "      <td>Jones</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student11@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>12</td>\n",
+              "      <td>Joshua</td>\n",
+              "      <td>Miller</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student12@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>14</td>\n",
+              "      <td>Jane</td>\n",
+              "      <td>Brown</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student14@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>28</td>\n",
+              "      <td>James</td>\n",
+              "      <td>Thomas</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student28@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>29</td>\n",
+              "      <td>Daniel</td>\n",
+              "      <td>White</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student29@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>11</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student30@school.com</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "    student_id first_name  last_name grade_level                 email\n",
+              "0            1       Ryan    Sanchez        12th   student1@school.com\n",
+              "1            3       John      Smith        12th   student3@school.com\n",
+              "2            4        Ava     Harris        12th   student4@school.com\n",
+              "3            7    Brandon   Thompson        12th   student7@school.com\n",
+              "4            9       Zach  Hernandez        12th   student9@school.com\n",
+              "5           10       Emma  Rodriguez        12th  student10@school.com\n",
+              "6           11       Alex      Jones        12th  student11@school.com\n",
+              "7           12     Joshua     Miller        12th  student12@school.com\n",
+              "8           14       Jane      Brown        12th  student14@school.com\n",
+              "9           28      James     Thomas        12th  student28@school.com\n",
+              "10          29     Daniel      White        12th  student29@school.com\n",
+              "11          30   Isabella   Anderson        12th  student30@school.com"
+            ]
+          },
+          "execution_count": 75,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "where_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT *\n",
+        "FROM students\n",
+        "WHERE grade_level = '12th';\n",
         "\"\"\"\n",
         "\n",
         "sql(where_query)"
@@ -260,7 +489,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 76,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -268,7 +497,15 @@
         "id": "cDz4qoWDUjFR",
         "outputId": "287c17e8-7696-4679-d906-d1717dcc79cb"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "WHERE query was successful: All rows have grade_level '12th'\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.where_test(where_query)"
       ]
@@ -289,7 +526,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 77,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -298,10 +535,99 @@
         "id": "qmmbO6_G_eQH",
         "outputId": "c7f5cd72-bd91-44b8-c662-9219f494ba6a"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student30@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>14</td>\n",
+              "      <td>Jane</td>\n",
+              "      <td>Brown</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student14@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>18</td>\n",
+              "      <td>Lily</td>\n",
+              "      <td>Clark</td>\n",
+              "      <td>11th</td>\n",
+              "      <td>student18@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>23</td>\n",
+              "      <td>Robert</td>\n",
+              "      <td>Davis</td>\n",
+              "      <td>11th</td>\n",
+              "      <td>student23@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>6</td>\n",
+              "      <td>Sarah</td>\n",
+              "      <td>Garcia</td>\n",
+              "      <td>10th</td>\n",
+              "      <td>student6@school.com</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   student_id first_name last_name grade_level                 email\n",
+              "0          30   Isabella  Anderson        12th  student30@school.com\n",
+              "1          14       Jane     Brown        12th  student14@school.com\n",
+              "2          18       Lily     Clark        11th  student18@school.com\n",
+              "3          23     Robert     Davis        11th  student23@school.com\n",
+              "4           6      Sarah    Garcia        10th   student6@school.com"
+            ]
+          },
+          "execution_count": 77,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "orderby_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT * \n",
+        "FROM students\n",
+        "ORDER by last_name ASC;\n",
         "\"\"\"\n",
         "\n",
         "sql(orderby_query).head()"
@@ -309,7 +635,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 78,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -317,7 +643,15 @@
         "id": "JhO4mItElv7B",
         "outputId": "ca61b168-988d-420b-e563-0a34d61bb2c8"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "ORDER BY query was successful: First few rows are sorted by last_name in ASC order\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.orderby_test(orderby_query, order='ASC')"
       ]
@@ -339,7 +673,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 79,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -348,10 +682,100 @@
         "id": "LXRQCzra_mez",
         "outputId": "6183a561-17c8-4ef8-dba0-14799ab24161"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade_level</th>\n",
+              "      <th>email</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student30@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>14</td>\n",
+              "      <td>Jane</td>\n",
+              "      <td>Brown</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student14@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>4</td>\n",
+              "      <td>Ava</td>\n",
+              "      <td>Harris</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student4@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>9</td>\n",
+              "      <td>Zach</td>\n",
+              "      <td>Hernandez</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student9@school.com</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>11</td>\n",
+              "      <td>Alex</td>\n",
+              "      <td>Jones</td>\n",
+              "      <td>12th</td>\n",
+              "      <td>student11@school.com</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   student_id first_name  last_name grade_level                 email\n",
+              "0          30   Isabella   Anderson        12th  student30@school.com\n",
+              "1          14       Jane      Brown        12th  student14@school.com\n",
+              "2           4        Ava     Harris        12th   student4@school.com\n",
+              "3           9       Zach  Hernandez        12th   student9@school.com\n",
+              "4          11       Alex      Jones        12th  student11@school.com"
+            ]
+          },
+          "execution_count": 79,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "multi_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT *\n",
+        "FROM students\n",
+        "WHERE grade_level = '12th'\n",
+        "ORDER BY last_name ASC;\n",
         "\"\"\"\n",
         "\n",
         "sql(multi_query).head()"
@@ -359,7 +783,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 80,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -367,7 +791,15 @@
         "id": "siwyDYNMZp4U",
         "outputId": "0ba592e7-c295-44f5-c9f2-7e628410fa58"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Multi-query was successful: All rows have grade_level '12th' and are sorted by last_name\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.multi_query_test(multi_query)"
       ]
@@ -440,14 +872,161 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 81,
       "metadata": {
         "id": "O0fDhR0J2DFq"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>student_id</th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>assignment_id</th>\n",
+              "      <th>grade</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>1</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>2</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>3</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>4</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>1</td>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>5</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>295</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>6</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>296</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>7</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>297</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>8</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>298</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>9</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>299</th>\n",
+              "      <td>30</td>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>10</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>300 rows × 5 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "     student_id first_name last_name  assignment_id grade\n",
+              "0             1       Ryan   Sanchez              1     F\n",
+              "1             1       Ryan   Sanchez              2     A\n",
+              "2             1       Ryan   Sanchez              3     B\n",
+              "3             1       Ryan   Sanchez              4     A\n",
+              "4             1       Ryan   Sanchez              5     A\n",
+              "..          ...        ...       ...            ...   ...\n",
+              "295          30   Isabella  Anderson              6     A\n",
+              "296          30   Isabella  Anderson              7     D\n",
+              "297          30   Isabella  Anderson              8     D\n",
+              "298          30   Isabella  Anderson              9     A\n",
+              "299          30   Isabella  Anderson             10     D\n",
+              "\n",
+              "[300 rows x 5 columns]"
+            ]
+          },
+          "execution_count": 81,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "left_join_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT students.student_id, students.first_name, students.last_name, grades.assignment_id, grades.grade\n",
+        "FROM students\n",
+        "LEFT JOIN grades\n",
+        "    ON students.student_id = grades.student_id;\n",
         "\"\"\"\n",
         "\n",
         "left_join = sql(left_join_query)\n",
@@ -456,7 +1035,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 82,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -464,7 +1043,16 @@
         "id": "xtxCslM9qEjQ",
         "outputId": "ee17009e-dfe0-4abf-e8cd-edda4de9c8a2"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "LEFT JOIN query shape is correct: (300, 5)\n",
+            "LEFT JOIN query contains all expected columns.\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.left_join_test(left_join_query)"
       ]
@@ -480,10 +1068,9 @@
         "1. Perform an INNER JOIN with the grades table on the common student_id column.\n",
         "1. Select the following columns in your query:\n",
         "\n",
-        "  - student_id from the students table\n",
+        "\n",
         "  - first_name from the students table\n",
         "  - last_name from the students table\n",
-        "  - assignment_id from the grades table\n",
         "  - grade from the grades table\n",
         "\n",
         "1. Ensure that only the records where there is a matching student_id in both the students and grades tables are included in your result."
@@ -491,7 +1078,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 83,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -500,10 +1087,133 @@
         "id": "1bZxKJPyQEUp",
         "outputId": "c68992b1-a06a-4b7c-98b5-5a506979656a"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>first_name</th>\n",
+              "      <th>last_name</th>\n",
+              "      <th>grade</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>A</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Ryan</td>\n",
+              "      <td>Sanchez</td>\n",
+              "      <td>B</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>295</th>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>296</th>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>297</th>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>D</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>298</th>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>299</th>\n",
+              "      <td>Isabella</td>\n",
+              "      <td>Anderson</td>\n",
+              "      <td>F</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>300 rows × 3 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "    first_name last_name grade\n",
+              "0         Ryan   Sanchez     A\n",
+              "1         Ryan   Sanchez     A\n",
+              "2         Ryan   Sanchez     A\n",
+              "3         Ryan   Sanchez     A\n",
+              "4         Ryan   Sanchez     B\n",
+              "..         ...       ...   ...\n",
+              "295   Isabella  Anderson     D\n",
+              "296   Isabella  Anderson     D\n",
+              "297   Isabella  Anderson     D\n",
+              "298   Isabella  Anderson     F\n",
+              "299   Isabella  Anderson     F\n",
+              "\n",
+              "[300 rows x 3 columns]"
+            ]
+          },
+          "execution_count": 83,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "inner_join_query = \"\"\"\n",
-        "YOUR QUERY HERE\n",
+        "SELECT students.first_name, students.last_name, grades.grade\n",
+        "FROM students\n",
+        "INNER JOIN grades\n",
+        "    ON students.student_id = grades.student_id;\n",
         "\"\"\"\n",
         "\n",
         "inner_join = sql(inner_join_query)\n",
@@ -512,7 +1222,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 84,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -520,7 +1230,16 @@
         "id": "BfQk9Qhittb5",
         "outputId": "c18623a2-c88b-4bec-fa66-edc2580af36d"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "INNER JOIN query shape is correct: (300, 3)\n",
+            "INNER JOIN query contains all expected columns.\n"
+          ]
+        }
+      ],
       "source": [
         "test_instance.inner_join_test(inner_join_query)"
       ]
@@ -568,11 +1287,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 85,
       "metadata": {
         "id": "CSY0UdZThguJ"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "OperationalError",
+          "evalue": "near \"YOUR\": syntax error",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[1;31mOperationalError\u001b[0m                          Traceback (most recent call last)",
+            "Cell \u001b[1;32mIn[85], line 5\u001b[0m\n\u001b[0;32m      1\u001b[0m insert_query \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;124mYOUR QUERY HERE\u001b[39m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[1;32m----> 5\u001b[0m \u001b[43mconn\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43minsert_query\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m      6\u001b[0m conn\u001b[38;5;241m.\u001b[39mcommit()\n\u001b[0;32m      8\u001b[0m student_31 \u001b[38;5;241m=\u001b[39m sql(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSELECT * FROM students WHERE student_id = 31\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+            "\u001b[1;31mOperationalError\u001b[0m: near \"YOUR\": syntax error"
+          ]
+        }
+      ],
       "source": [
         "insert_query = \"\"\"\n",
         "YOUR QUERY HERE\n",
@@ -1402,7 +2133,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "venv",
+      "display_name": "env",
       "language": "python",
       "name": "python3"
     },
@@ -1416,7 +2147,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.1"
+      "version": "3.13.2"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
… answer correctly
The answer on exercise 2, inner joins showed 3 columns, but you asked for 5 columns in the question. I tried to update the function to include all 5 columns, but that didn't work, not sure why (I added the column names and changed the size to 300, 5 in all applicable places). As I needed to get on with my work, I decided to update the test itself to request the 3 columns you checked for in the answer, removing assignment_id and student_id in the markdown area. 

Inner join Instructions:
1. Use the students table as the primary table.
1. Perform an INNER JOIN with the grades table on the common student_id column.
1. Select the following columns in your query:


  - first_name from the students table
  - last_name from the students table
  - grade from the grades table

1. Ensure that only the records where there is a matching student_id in both the students and grades tables are included in your result.